### PR TITLE
tests: add predict script and API endpoint tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+
+
+def setup_module():
+    # Ensure processed data and model exist
+    subprocess.run([sys.executable, "src/preprocess.py"], check=True)
+    subprocess.run([sys.executable, "src/train.py"], check=True)
+
+
+def test_api_predict_endpoint():
+    import app
+
+    client = app.app.test_client()
+    res = client.post("/predict", json={"features": [5, 6]})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert "prediction" in data
+    assert data["prediction"] in (0, 1)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+
+
+def setup_module():
+    # Ensure processed data and model exist
+    subprocess.run([sys.executable, "src/preprocess.py"], check=True)
+    subprocess.run([sys.executable, "src/train.py"], check=True)
+
+
+def test_predict_script_outputs_prediction():
+    res = subprocess.run([sys.executable, "src/predict.py"], capture_output=True, text=True, check=True)
+    assert "Prediction:" in res.stdout


### PR DESCRIPTION
## Summary
Adds automated tests to validate that the model artifact is created and that the Flask API `/predict` endpoint returns a valid prediction.

## What I changed
- Added `tests/test_predict.py` — runs `src/preprocess.py` and `src/train.py`, then asserts `src/predict.py` emits a `Prediction:` line.
- Added `tests/test_api.py` — runs preprocessing/training and asserts the Flask `/predict` endpoint returns HTTP 200 and a `prediction` value in (0,1).

## Why
These tests increase confidence in the CI pipeline by exercising both the model creation step and the API prediction endpoint used by the Docker image.

## How I tested locally
- Ran full pipeline locally:
  - `python src/preprocess.py`
  - `python src/train.py`
  - `python src/evaluate.py`
  - `pytest -q` — all tests passed (3 passed).
- Built and ran the Docker image locally; the API responded to `/` and `/predict`.

## Notes / Caveats
- The tests call the training pipeline and therefore produce the `models/model.pkl` artifact locally. This is intentional for CI validation.
- There are some design improvements we may want later (deterministic `random_state`, using a persisted test split, lightweight input validation in `app.py`).

## Checklist
- [ ] Tests pass in CI
- [ ] Approvals from reviewers (if required)