### PR TITLE
Fix: Resolve CI/CD pipeline failures (python-version + models directory) i221948_Activity 5

### DIFF
--- a/.github/workflows/ml-pipeline.yml
+++ b/.github/workflows/ml-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install Dependencies
       run: |

--- a/src/train.py
+++ b/src/train.py
@@ -2,17 +2,18 @@ import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 import joblib
+import os
 
 df = pd.read_csv("data/processed.csv")
 
 X = df[['feature1', 'feature2']]
 y = df['target']
-
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 
 model = RandomForestClassifier()
 model.fit(X_train, y_train)
 
+os.makedirs("models", exist_ok=True)
 joblib.dump(model, "models/model.pkl")
 
 print("Model Trained Successfully")


### PR DESCRIPTION
## Fixes Applied

**Fix 1: `fix/python-version`**
- Problem: `python-version: 3.10` was parsed by YAML as float 3.1, causing Python version not found error
- Fix: Changed to `python-version: "3.10"` (quoted string)

**Fix 2: `fix/create-models-directory`**
- Problem: `models/` directory didn't exist in CI, joblib couldn't save model.pkl
- Fix: Added `os.makedirs("models", exist_ok=True)` in train.py before saving the model

Both fixes verified — pipeline fully passing (all steps green).