### PR TITLE
Fix: Gave specific dependency versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pandas
-numpy
-scikit-learn
-joblib
-flask
-pytest
+pandas==2.2.0
+numpy==1.26.4
+scikit-learn==1.4.0
+joblib==1.3.2
+flask==3.0.2
+pytest==8.1.0


### PR DESCRIPTION
Gave specific versions so that the pipeline wouldn't break due to mismatch of versions. pinned all package versions for reproducible builds