### PR TITLE
fix: resolve CI/CD pipeline failures (python version, split mismatch, validation)

### DIFF
--- a/.github/workflows/ml-pipeline.yml
+++ b/.github/workflows/ml-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"   # Fix: quoted string to prevent YAML float parsing (3.10 → 3.1)
 
     - name: Install Dependencies
       run: |

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -8,7 +8,8 @@ df = pd.read_csv("data/processed.csv")
 X = df[['feature1', 'feature2']]
 y = df['target']
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+# 22I-1936: added random_state=42 to match the same split used during training
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
 model = joblib.load("models/model.pkl")
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,6 +1,22 @@
 import pandas as pd
+import sys
+
+# Fix: added input validation for required columns and data integrity
+REQUIRED_COLUMNS = ['feature1', 'feature2', 'target']
 
 df = pd.read_csv("data/sample.csv")
+
+# Validate required columns exist
+missing_cols = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+if missing_cols:
+    print(f"ERROR: Missing required columns: {missing_cols}")
+    sys.exit(1)
+
+# Validate no all-NaN columns
+if df[REQUIRED_COLUMNS].isnull().all().any():
+    print("ERROR: One or more required columns are entirely NaN.")
+    sys.exit(1)
+
 df.dropna(inplace=True)
 df.to_csv("data/processed.csv", index=False)
 

--- a/src/train.py
+++ b/src/train.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
@@ -8,11 +9,14 @@ df = pd.read_csv("data/processed.csv")
 X = df[['feature1', 'feature2']]
 y = df['target']
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+# 22I-1936:  added random_state=42 to ensure consistent split between train and evaluate
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
-model = RandomForestClassifier()
+model = RandomForestClassifier(random_state=42)
 model.fit(X_train, y_train)
 
+# 22I-1936: create models/ directory if it doesn't exist
+os.makedirs("models", exist_ok=True)
 joblib.dump(model, "models/model.pkl")
 
 print("Model Trained Successfully")


### PR DESCRIPTION
## CI/CD Issues Fixed

**1. Python version YAML bug** — `python-version: 3.10` parsed as float 3.1 → fixed to `"3.10"`

**2. Train-test split mismatch** — train.py and evaluate.py used different random splits → added `random_state=42` to both

**3. Missing `models/` directory** — `joblib.dump` crashed if dir absent → added `os.makedirs`

**4. Input validation** — preprocess.py had no column checks → added required column validation

Author: syedaemanali9903@gmail.com