### PR TITLE
fix(ci): create models directory and stabilize training split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 models/*.pkl
+.venv/
+.env

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ python app.py
 
 Push code to main branch → pipeline auto runs.
 
+## Submitting a pull request (assignment)
+
+Fork [mateenyaqoob/CI-CD-for-ML-using-GitHub-Actions](https://github.com/mateenyaqoob/CI-CD-for-ML-using-GitHub-Actions) on GitHub, push a branch with your fixes to your fork, then open a pull request against the upstream `main` branch. On macOS, if `git` reports an Xcode license error, run `sudo xcodebuild -license` once to accept the license, or use [GitHub Desktop](https://desktop.github.com/) to clone your fork and push without the command-line tools conflict.
+
 ## Structure
 ml-cicd-github-actions/
 

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -8,7 +8,9 @@ df = pd.read_csv("data/processed.csv")
 X = df[['feature1', 'feature2']]
 y = df['target']
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, random_state=42
+)
 
 model = joblib.load("models/model.pkl")
 

--- a/src/train.py
+++ b/src/train.py
@@ -1,18 +1,23 @@
-import pandas as pd
-from sklearn.model_selection import train_test_split
-from sklearn.ensemble import RandomForestClassifier
+from pathlib import Path
+
 import joblib
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
 
 df = pd.read_csv("data/processed.csv")
 
-X = df[['feature1', 'feature2']]
-y = df['target']
+X = df[["feature1", "feature2"]]
+y = df["target"]
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, random_state=42
+)
 
-model = RandomForestClassifier()
+model = RandomForestClassifier(random_state=42)
 model.fit(X_train, y_train)
 
+Path("models").mkdir(parents=True, exist_ok=True)
 joblib.dump(model, "models/model.pkl")
 
 print("Model Trained Successfully")


### PR DESCRIPTION
Fixes CI failure when saving `models/model.pkl` because the `models/` directory did not exist on a fresh checkout.

- Create `models` before `joblib.dump`
- Use `random_state=42` for `train_test_split` and `RandomForestClassifier` so train/evaluate splits match and runs are reproducible
- Extend `.gitignore` (`.venv/`, `.env`)
- README: fork/PR notes for the assignment
