### PR TITLE
fix: create models folder to prevent CI failure

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -2,6 +2,7 @@ import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 import joblib
+from pathlib import Path
 
 df = pd.read_csv("data/processed.csv")
 
@@ -13,6 +14,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 model = RandomForestClassifier()
 model.fit(X_train, y_train)
 
+Path("models").mkdir(parents=True, exist_ok=True)
 joblib.dump(model, "models/model.pkl")
 
 print("Model Trained Successfully")


### PR DESCRIPTION
This PR fixes the CI/CD failure by ensuring the models directory exists before saving the trained model artifact.\n\nAuthor: Ali Zaib