### PR TITLE
fix(ci): models directory, Python 3.10 YAML, ignore processed data

### DIFF
--- a/.github/workflows/ml-pipeline.yml
+++ b/.github/workflows/ml-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install Dependencies
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 models/*.pkl
+data/processed.csv

--- a/src/train.py
+++ b/src/train.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
@@ -13,6 +14,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 model = RandomForestClassifier()
 model.fit(X_train, y_train)
 
+os.makedirs("models", exist_ok=True)
 joblib.dump(model, "models/model.pkl")
 
 print("Model Trained Successfully")


### PR DESCRIPTION
## Summary
Fixes CI failures on a clean checkout and in GitHub Actions.

## Changes
- **Training:** create \models/\ before \joblib.dump\ and add \models/.gitkeep\ (avoids \FileNotFoundError\ for \models/model.pkl\).
- **Workflow:** quote \python-version: '3.10'\ so YAML does not parse \3.10\ as float \3.1\ (which broke \ctions/setup-python\).
- **Gitignore:** ignore generated \data/processed.csv\.

## Verification
CI pipeline passes locally and on fork Actions (preprocess, train, evaluate, pytest, Docker build).