### PR TITLE
Fix: Add random_state to train_test_split for reproducibility

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -8,7 +8,7 @@ df = pd.read_csv("data/processed.csv")
 X = df[['feature1', 'feature2']]
 y = df['target']
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
 model = joblib.load("models/model.pkl")
 

--- a/src/train.py
+++ b/src/train.py
@@ -8,7 +8,7 @@ df = pd.read_csv("data/processed.csv")
 X = df[['feature1', 'feature2']]
 y = df['target']
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
 model = RandomForestClassifier()
 model.fit(X_train, y_train)

--- a/test_model.py
+++ b/test_model.py
@@ -1,7 +1,22 @@
 import joblib
 import numpy as np
 
+
 def test_prediction():
+    """Test that model predictions return valid class labels (0 or 1)."""
     model = joblib.load("models/model.pkl")
-    pred = model.predict(np.array([[5,6]]))
-    assert pred[0] in [0,1]
+    pred = model.predict(np.array([[5, 6]]))
+    assert pred[0] in [0, 1], f"Prediction {pred[0]} is not a valid class label"
+
+
+def test_model_exists():
+    """Test that trained model file exists."""
+    import os
+    assert os.path.exists("models/model.pkl"), "Model file not found"
+
+
+def test_prediction_shape():
+    """Test that prediction returns correct output shape."""
+    model = joblib.load("models/model.pkl")
+    pred = model.predict(np.array([[5, 6]]))
+    assert pred.shape == (1,), f"Expected shape (1,), got {pred.shape}"


### PR DESCRIPTION
Fixes non-deterministic behavior in CI/CD pipeline.

Changes:
- Set random_state=42 in src/train.py
- Set random_state=42 in src/evaluate.py
- Ensures consistent data splits across CI/CD runs for deterministic behavior

This prevents random test failures due to different train/test splits.