### PR TITLE
fix: resolve critical CI pipeline bugs, pin deps, and harden ML scripts

### DIFF
--- a/.github/workflows/ml-pipeline.yml
+++ b/.github/workflows/ml-pipeline.yml
@@ -16,7 +16,14 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
 
     - name: Install Dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10-slim
 
 WORKDIR /app
 

--- a/app.py
+++ b/app.py
@@ -1,10 +1,12 @@
+import os
 from flask import Flask, request, jsonify
 import joblib
 import numpy as np
 
 app = Flask(__name__)
 
-model = joblib.load("models/model.pkl")
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+model = joblib.load(os.path.join(BASE_DIR, "models", "model.pkl"))
 
 @app.route("/")
 def home():
@@ -13,6 +15,8 @@ def home():
 @app.route("/predict", methods=["POST"])
 def predict():
     data = request.json
+    if not data or "features" not in data:
+        return jsonify({"error": "Missing 'features' key in request body"}), 400
     values = np.array([data["features"]])
     pred = model.predict(values)
     return jsonify({"prediction": int(pred[0])})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pandas
-numpy
-scikit-learn
-joblib
-flask
-pytest
+pandas==2.2.2
+numpy==1.26.4
+scikit-learn==1.4.2
+joblib==1.4.2
+flask==3.0.3
+pytest==8.2.0

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -8,7 +8,7 @@ df = pd.read_csv("data/processed.csv")
 X = df[['feature1', 'feature2']]
 y = df['target']
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
 model = joblib.load("models/model.pkl")
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,7 +1,15 @@
 import pandas as pd
 
 df = pd.read_csv("data/sample.csv")
+
+required_cols = ['feature1', 'feature2', 'target']
+missing = set(required_cols) - set(df.columns)
+assert not missing, f"Missing expected columns: {missing}"
+
+print(f"Rows before dropna: {len(df)}")
 df.dropna(inplace=True)
+print(f"Rows after dropna: {len(df)}")
+
 df.to_csv("data/processed.csv", index=False)
 
 print("Preprocessing Completed")

--- a/src/train.py
+++ b/src/train.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
@@ -8,11 +9,12 @@ df = pd.read_csv("data/processed.csv")
 X = df[['feature1', 'feature2']]
 y = df['target']
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
-model = RandomForestClassifier()
+model = RandomForestClassifier(random_state=42)
 model.fit(X_train, y_train)
 
+os.makedirs("models", exist_ok=True)
 joblib.dump(model, "models/model.pkl")
 
 print("Model Trained Successfully")

--- a/test_model.py
+++ b/test_model.py
@@ -1,7 +1,9 @@
+import os
 import joblib
 import numpy as np
 
 def test_prediction():
-    model = joblib.load("models/model.pkl")
-    pred = model.predict(np.array([[5,6]]))
-    assert pred[0] in [0,1]
+    model_path = os.path.join(os.path.dirname(__file__), "models", "model.pkl")
+    model = joblib.load(model_path)
+    pred = model.predict(np.array([[5, 6]]))
+    assert pred[0] in [0, 1]


### PR DESCRIPTION
Fixes 4 critical bugs breaking the CI pipeline: models/ directory not created before saving the model, Python version unquoted in YAML (3.10 → "3.10"), missing random_state in evaluate.py, and fragile relative model paths. Also pins dependency versions, adds pip caching, input validation on /predict, and switches to a slim Docker base image.