### PR TITLE
fix: quote python-version to prevent YAML float parsing (issue #21)

### DIFF
--- a/.github/workflows/ml-pipeline.yml
+++ b/.github/workflows/ml-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
Closes #21 — YAML parses 3.10 as float 3.1, installing wrong Python. Quoting the value fixes this.