### PR TITLE
fix: use pathlib for reliable dataset path resolution

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,16 +1,19 @@
+from pathlib import Path
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
 import joblib
 
-df = pd.read_csv("data/processed.csv")
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+df = pd.read_csv(BASE_DIR / "data" / "processed.csv")
 
 X = df[['feature1', 'feature2']]
 y = df['target']
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 
-model = joblib.load("models/model.pkl")
+model = joblib.load(BASE_DIR / "models" / "model.pkl")
 
 pred = model.predict(X_test)
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,7 +1,10 @@
+from pathlib import Path
 import pandas as pd
 
-df = pd.read_csv("data/sample.csv")
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+df = pd.read_csv(BASE_DIR / "data" / "sample.csv")
 df.dropna(inplace=True)
-df.to_csv("data/processed.csv", index=False)
+df.to_csv(BASE_DIR / "data" / "processed.csv", index=False)
 
 print("Preprocessing Completed")

--- a/src/train.py
+++ b/src/train.py
@@ -1,9 +1,12 @@
+from pathlib import Path
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 import joblib
 
-df = pd.read_csv("data/processed.csv")
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+df = pd.read_csv(BASE_DIR / "data" / "processed.csv")
 
 X = df[['feature1', 'feature2']]
 y = df['target']
@@ -13,6 +16,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 model = RandomForestClassifier()
 model.fit(X_train, y_train)
 
-joblib.dump(model, "models/model.pkl")
+(BASE_DIR / "models").mkdir(exist_ok=True)
+joblib.dump(model, BASE_DIR / "models" / "model.pkl")
 
 print("Model Trained Successfully")


### PR DESCRIPTION
Closes #50 — Replaced hard-coded relative paths with pathlib.Path(__file__).resolve().parent.parent so scripts work from any working directory.