### PR TITLE
fix(train): create models/ directory before saving model (#31)

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -1,3 +1,5 @@
+import os
+
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
@@ -13,6 +15,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 model = RandomForestClassifier()
 model.fit(X_train, y_train)
 
+os.makedirs("models", exist_ok=True)
 joblib.dump(model, "models/model.pkl")
 
 print("Model Trained Successfully")


### PR DESCRIPTION
## Summary
- Adds `os.makedirs(\"models\", exist_ok=True)` in `src/train.py` immediately before `joblib.dump(...)` so the destination directory always exists when the model is persisted.
- Resolves a hard `FileNotFoundError` on every fresh checkout because `models/` is excluded by `.gitignore` and is therefore never present when CI starts.

## Why this fixes issue #31
`joblib.dump(model, \"models/model.pkl\")` requires the parent directory to exist. On a clean clone — exactly what GitHub Actions does on every run — `models/` is absent, so the call fails with `FileNotFoundError: [Errno 2] No such file or directory: 'models/model.pkl'`. Creating the directory with `exist_ok=True` is idempotent: it's a no-op when the folder already exists locally and the fix needed for fresh CI environments.

## Test plan
- [x] Verified locally in a clean working directory (no `models/`): `python src/preprocess.py && python src/train.py` now succeeds and produces `models/model.pkl`.
- [ ] CI workflow on this PR should pass the `Train Model` step (assuming #21 / #50 are also resolved or merged separately).

Closes #31