### PR TITLE
fix(src): anchor data/model paths to repo root via pathlib (#50)

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,16 +1,22 @@
+from pathlib import Path
+
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
 import joblib
 
-df = pd.read_csv("data/processed.csv")
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
+MODELS_DIR = ROOT / "models"
+
+df = pd.read_csv(DATA_DIR / "processed.csv")
 
 X = df[['feature1', 'feature2']]
 y = df['target']
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 
-model = joblib.load("models/model.pkl")
+model = joblib.load(MODELS_DIR / "model.pkl")
 
 pred = model.predict(X_test)
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -1,7 +1,12 @@
+from pathlib import Path
+
 import joblib
 import numpy as np
 
-model = joblib.load("models/model.pkl")
+ROOT = Path(__file__).resolve().parent.parent
+MODELS_DIR = ROOT / "models"
+
+model = joblib.load(MODELS_DIR / "model.pkl")
 
 sample = np.array([[5,6]])
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,7 +1,12 @@
+from pathlib import Path
+
 import pandas as pd
 
-df = pd.read_csv("data/sample.csv")
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
+
+df = pd.read_csv(DATA_DIR / "sample.csv")
 df.dropna(inplace=True)
-df.to_csv("data/processed.csv", index=False)
+df.to_csv(DATA_DIR / "processed.csv", index=False)
 
 print("Preprocessing Completed")

--- a/src/train.py
+++ b/src/train.py
@@ -1,9 +1,15 @@
+from pathlib import Path
+
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 import joblib
 
-df = pd.read_csv("data/processed.csv")
+ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = ROOT / "data"
+MODELS_DIR = ROOT / "models"
+
+df = pd.read_csv(DATA_DIR / "processed.csv")
 
 X = df[['feature1', 'feature2']]
 y = df['target']
@@ -13,6 +19,6 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
 model = RandomForestClassifier()
 model.fit(X_train, y_train)
 
-joblib.dump(model, "models/model.pkl")
+joblib.dump(model, MODELS_DIR / "model.pkl")
 
 print("Model Trained Successfully")


### PR DESCRIPTION
## Summary
- Replaces hard-coded relative paths (`\"data/sample.csv\"`, `\"models/model.pkl\"`, etc.) in `preprocess.py`, `train.py`, `evaluate.py`, and `predict.py` with `Path(__file__).resolve().parent.parent`-anchored paths.
- The scripts now resolve `data/` and `models/` relative to the repository root instead of the caller's current working directory, eliminating the `FileNotFoundError` that occurs whenever the scripts are invoked from anywhere other than the repo root (local `cd src && python train.py`, certain Docker layers, IDE run configurations, etc.).

## Why this fixes issue #50
`pd.read_csv(\"data/sample.csv\")` resolves against `os.getcwd()`, not against the script's location. Any environment that does not happen to start at the repo root — and there are several in the assignment workflow — will fail to locate the dataset. Computing a stable `ROOT = Path(__file__).resolve().parent.parent` and joining sub-paths against it makes the scripts location-independent.

## Test plan
- [x] `cd src && python preprocess.py && python train.py && python evaluate.py && python predict.py` succeeds end-to-end (previously every one of these would raise `FileNotFoundError`).
- [x] Running each script from the repo root still works unchanged.
- [ ] CI workflow continues to pass with the existing `python src/<script>.py` invocations.

Closes #50